### PR TITLE
Loosen readable-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"test" : "mocha --reporter spec"
 	},
 	"dependencies" : {
-		"readable-stream" : "1.0.2"
+		"readable-stream" : "1.0.x"
 	},
 	"devDependencies" : {
 		"mocha" : "*",


### PR DESCRIPTION
There have been several 1.0.x patch releases since this dependency was set, and it would be nice to keep up with the latest ports from node core (for v0.10.x/Streams2 compatibility).
